### PR TITLE
Implemented support for LuckPerms group attribute based ban time.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.backtobedrock</groupId>
     <artifactId>AugmentedHardcore</artifactId>
-    <version>3.3.2</version>
+    <version>3.3.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -111,6 +111,12 @@
             <groupId>com.SirBlobman.combatlogx</groupId>
             <artifactId>CombatLogX-API</artifactId>
             <version>10.0.0.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.luckperms</groupId>
+            <artifactId>api</artifactId>
+            <version>5.3</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -7,6 +7,9 @@ import com.backtobedrock.augmentedhardcore.domain.data.ServerData;
 import com.backtobedrock.augmentedhardcore.domain.enums.StorageType;
 import com.backtobedrock.augmentedhardcore.eventListeners.*;
 import com.backtobedrock.augmentedhardcore.eventListeners.dependencies.ListenerCombatLogX;
+import com.backtobedrock.augmentedhardcore.groups.DummyGroupHandler;
+import com.backtobedrock.augmentedhardcore.groups.GroupHandler;
+import com.backtobedrock.augmentedhardcore.groups.LuckPermsGroupHandler;
 import com.backtobedrock.augmentedhardcore.guis.AbstractGui;
 import com.backtobedrock.augmentedhardcore.guis.GuiMyStats;
 import com.backtobedrock.augmentedhardcore.mappers.Patch;
@@ -58,6 +61,8 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
     //runnables
     private UpdateChecker updateChecker;
 
+    private static GroupHandler groupHandler;
+
     @Override
     public void onEnable() {
         this.initialize();
@@ -82,6 +87,13 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
         }
 
         super.onEnable();
+    }
+
+    /**
+     * @return The group handler.
+     */
+    public static GroupHandler getGroupHandler() {
+        return groupHandler;
     }
 
     @Override
@@ -150,6 +162,14 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
         }
         if (this.serverRepository == null) {
             this.serverRepository = new ServerRepository();
+        }
+
+        AugmentedHardcore.groupHandler = new DummyGroupHandler();
+        if(Bukkit.getPluginManager().getPlugin("LuckPerms") != null) {
+            String groupBanTimeAttributeName = this.configurations.getDeathBanConfiguration().getGroupBanTimeAttributeName();
+            if(groupBanTimeAttributeName != null) {
+                AugmentedHardcore.groupHandler = new LuckPermsGroupHandler(groupBanTimeAttributeName);
+            }
         }
 
         //register event listeners

--- a/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationDeathBan.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationDeathBan.java
@@ -29,8 +29,12 @@ public class ConfigurationDeathBan {
     private final World spectatorBanRespawnWorld;
     private final List<String> commandsOnDeathBan;
     private final List<String> disableBanInWorlds;
+    private final String groupBanTimeAttributeName;
 
-    public ConfigurationDeathBan(boolean useDeathBan, EnumMap<DamageCause, BanConfiguration> banTimes, BanList.Type banType, BanTimeType banTimeType, GrowthType banTimeByPlaytimeGrowthType, boolean selfHarmBan, boolean lightningOnDeathBan, World spectatorBanRespawnWorld, List<String> commandsOnDeathBan, List<String> disableBanInWorlds) {
+    public ConfigurationDeathBan(boolean useDeathBan, EnumMap<DamageCause, BanConfiguration> banTimes, BanList.Type banType,
+                                 BanTimeType banTimeType, GrowthType banTimeByPlaytimeGrowthType, boolean selfHarmBan,
+                                 boolean lightningOnDeathBan, World spectatorBanRespawnWorld, List<String> commandsOnDeathBan,
+                                 List<String> disableBanInWorlds, String groupBanTimeAttributeName) {
         this.useDeathBan = useDeathBan;
         this.banTimes = banTimes;
         this.banType = banType;
@@ -41,6 +45,7 @@ public class ConfigurationDeathBan {
         this.spectatorBanRespawnWorld = spectatorBanRespawnWorld;
         this.commandsOnDeathBan = commandsOnDeathBan;
         this.disableBanInWorlds = disableBanInWorlds;
+        this.groupBanTimeAttributeName = groupBanTimeAttributeName;
     }
 
     public static ConfigurationDeathBan deserialize(ConfigurationSection section) {
@@ -57,6 +62,7 @@ public class ConfigurationDeathBan {
         World cSpectatorBanRespawnWorld = ConfigUtils.getWorld(section.getString("SpectatorBanRespawnWorld"), Bukkit.getWorlds().get(0));
         List<String> cCommandsOnDeathBan = section.getStringList("CommandsOnDeathBan");
         List<String> cDisableBanInWorlds = ConfigUtils.getWorlds("DisableBanInWorlds", section.getStringList("DisableBanInWorlds"));
+        String cGroupBanTimeAttributeName = section.getString("GroupBanTimeAttributeName", null);
 
         //loop over all damage causes
         ConfigurationSection banTimesConfigurations = section.getConfigurationSection("BanTimes");
@@ -83,7 +89,8 @@ public class ConfigurationDeathBan {
                 cLightningOnDeathBan,
                 cSpectatorBanRespawnWorld,
                 cCommandsOnDeathBan,
-                cDisableBanInWorlds
+                cDisableBanInWorlds,
+                cGroupBanTimeAttributeName
         );
     }
 
@@ -93,6 +100,10 @@ public class ConfigurationDeathBan {
 
     public List<String> getDisableBanInWorlds() {
         return disableBanInWorlds;
+    }
+
+    public String getGroupBanTimeAttributeName() {
+        return groupBanTimeAttributeName;
     }
 
     public BanList.Type getBanType() {

--- a/src/com/backtobedrock/augmentedhardcore/domain/enums/BanTimeType.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/enums/BanTimeType.java
@@ -2,7 +2,9 @@ package com.backtobedrock.augmentedhardcore.domain.enums;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.data.PlayerData;
+import com.backtobedrock.augmentedhardcore.groups.GroupHandler;
 import com.backtobedrock.augmentedhardcore.utilities.MessageUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.Statistic;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -10,6 +12,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.time.LocalDateTime;
 
 public enum BanTimeType {
+    GROUP,
     STATIC,
     BANCOUNT,
     PLAYTIME,
@@ -18,6 +21,19 @@ public enum BanTimeType {
     public int getBantime(Player player, PlayerData playerData, int max) {
         GrowthType growthType = JavaPlugin.getPlugin(AugmentedHardcore.class).getConfigurations().getDeathBanConfiguration().getBanTimeByPlaytimeGrowthType();
         switch (this) {
+            case GROUP:
+                try {
+                    GroupHandler groupHandler = AugmentedHardcore.getGroupHandler();
+                    String textValue = (String)groupHandler.getAttribute(player);
+                    if(!textValue.isEmpty()) {
+                        return Integer.parseInt(textValue);
+                    }
+                    Bukkit.getLogger().warning("No ban time value found in group attribute.");
+                } catch(Exception e) {
+                    Bukkit.getLogger().warning("Failed to determine ban time value based on group, configuration invalid: " + e);
+                    e.printStackTrace();
+                }
+                return 0;
             case STATIC:
                 return max;
             case BANCOUNT:

--- a/src/com/backtobedrock/augmentedhardcore/groups/DummyGroupHandler.java
+++ b/src/com/backtobedrock/augmentedhardcore/groups/DummyGroupHandler.java
@@ -1,0 +1,17 @@
+package com.backtobedrock.augmentedhardcore.groups;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Dummy group handler is used if LuckPerms is not
+ * available, to avoid hard class dependencies.
+ *
+ * @author Marcel Schoen
+ */
+public class DummyGroupHandler implements GroupHandler {
+
+    @Override
+    public Object getAttribute(Player player) {
+        return "";
+    }
+}

--- a/src/com/backtobedrock/augmentedhardcore/groups/GroupHandler.java
+++ b/src/com/backtobedrock/augmentedhardcore/groups/GroupHandler.java
@@ -1,0 +1,17 @@
+package com.backtobedrock.augmentedhardcore.groups;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Handles processing group attributes of a player.
+ *
+ * @author Marcel Schoen
+ */
+public interface GroupHandler {
+
+    /**
+     * @param player The player for which to look up the group attribute value.
+     * @return The attribute value (or null).
+     */
+    public Object getAttribute(Player player);
+}

--- a/src/com/backtobedrock/augmentedhardcore/groups/LuckPermsGroupHandler.java
+++ b/src/com/backtobedrock/augmentedhardcore/groups/LuckPermsGroupHandler.java
@@ -1,0 +1,50 @@
+package com.backtobedrock.augmentedhardcore.groups;
+
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.model.group.Group;
+import net.luckperms.api.model.user.User;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+/**
+ * Reads the configured ban-time meta attribute from
+ * the player's LuckPerms group.
+ *
+ * @author Marcel Schoen
+ */
+public class LuckPermsGroupHandler implements GroupHandler {
+
+    private LuckPerms luckPerms = null;
+    private String attributeName = null;
+
+    /**
+     * @param attributeName The configured name of the LuckPerms group attribute.
+     */
+    public LuckPermsGroupHandler(String attributeName) {
+        RegisteredServiceProvider<LuckPerms> provider = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
+        if (provider != null) {
+            luckPerms = provider.getProvider();
+            this.attributeName = attributeName;
+        } else {
+            Bukkit.getLogger().warning("LuckPerms group handler not available!");
+        }
+    }
+
+    @Override
+    public Object getAttribute(Player player) {
+        if(luckPerms != null) {
+            User user = luckPerms.getPlayerAdapter(Player.class).getUser(player);
+            String groupName = user.getPrimaryGroup();
+            Group group = groupName == null ? null : luckPerms.getGroupManager().getGroup(groupName);
+            if(group != null) {
+                String result = luckPerms.getGroupManager().getGroup(groupName).getCachedData().getMetaData().getMetaValue(attributeName);
+                return result;
+            }
+        } else {
+            Bukkit.getLogger().warning("LuckPerms API not available, cannot resolve attribute '"
+                    + attributeName + "'!");
+        }
+        return "";
+    }
+}

--- a/src/resources/config.yml
+++ b/src/resources/config.yml
@@ -391,6 +391,15 @@ BanType: name
 # -> static/bancount/playtime/timesincelastdeath
 BanTimeType: static
 
+# IF "BanTimeType" is set to "group":
+# Name of LuckPerms group meta attribute containing the ban time in number of minutes.
+# Example LuckPerms group config lines:
+#
+# meta:
+#   - bantime:
+#       value: '960'
+GroupBanTimeAttributeName: bantime
+
 #At what rate should the ban time by playtime grow?
 #Linear:      a constant increase in bantime the more bancount/playtime/timesincelastdeath(P) you have (constant increase).
 #             Function: [(P+MBT/60) OR MBT]. MBT -> max ban time


### PR DESCRIPTION
This addition allows to use a group meta attribute in a "LuckPerms" group to define the ban time in minutes. So it's possible to ban the user for a certain time based on which rank/group he currently has. I use this to ban users with higher ranks for a longer time (which balances out the additional perks they have with their rank).

The change is written in a way to not create a hard dependency to "LuckPerms". It could also relatively easily be extended in the future to support other permission plugins like "EssentialsX". But for now I have just implemented what I need for my own server.