### PR TITLE
Group bans

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -10,7 +10,7 @@
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
-      <module name="AugmentedHardcore" target="8" />
+      <module name="AugmentedHardcore" target="1.8" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -12,5 +12,5 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_15" project-jdk-name="openjdk-16" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_16" project-jdk-name="17" project-jdk-type="JavaSDK" />
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.backtobedrock</groupId>
     <artifactId>AugmentedHardcore</artifactId>
-    <version>3.3.7</version>
+    <version>3.3.8-groupban-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <java.version>8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,5 +112,11 @@
             <artifactId>ConfigUpdater</artifactId>
             <version>2.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>net.luckperms</groupId>
+            <artifactId>api</artifactId>
+            <version>5.3</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -184,7 +184,8 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
         }
 
         AugmentedHardcore.groupHandler = new DummyGroupHandler();
-        if(Bukkit.getPluginManager().getPlugin("LuckPerms") != null) {
+        Object luckPermsPlugin = Bukkit.getPluginManager().getPlugin("LuckPerms");
+        if(luckPermsPlugin != null) {
             String groupBanTimeAttributeName = this.configurations.getDeathBanConfiguration().getGroupBanTimeAttributeName();
             if(groupBanTimeAttributeName != null) {
                 AugmentedHardcore.groupHandler = new LuckPermsGroupHandler(groupBanTimeAttributeName);

--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -7,6 +7,9 @@ import com.backtobedrock.augmentedhardcore.domain.data.ServerData;
 import com.backtobedrock.augmentedhardcore.domain.enums.StorageType;
 import com.backtobedrock.augmentedhardcore.eventListeners.*;
 import com.backtobedrock.augmentedhardcore.eventListeners.dependencies.ListenerCombatLogX;
+import com.backtobedrock.augmentedhardcore.groups.DummyGroupHandler;
+import com.backtobedrock.augmentedhardcore.groups.GroupHandler;
+import com.backtobedrock.augmentedhardcore.groups.LuckPermsGroupHandler;
 import com.backtobedrock.augmentedhardcore.guis.AbstractGui;
 import com.backtobedrock.augmentedhardcore.guis.GuiMyStats;
 import com.backtobedrock.augmentedhardcore.mappers.Patch;
@@ -55,6 +58,8 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
     //runnables
     private UpdateChecker updateChecker;
 
+    private static GroupHandler groupHandler;
+
     @Override
     public void onEnable() {
         this.initialize();
@@ -79,6 +84,13 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
         }
 
         super.onEnable();
+    }
+
+    /**
+     * @return The group handler.
+     */
+    public static GroupHandler getGroupHandler() {
+        return groupHandler;
     }
 
     @Override
@@ -169,6 +181,14 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
         }
         if (this.serverRepository == null) {
             this.serverRepository = new ServerRepository();
+        }
+
+        AugmentedHardcore.groupHandler = new DummyGroupHandler();
+        if(Bukkit.getPluginManager().getPlugin("LuckPerms") != null) {
+            String groupBanTimeAttributeName = this.configurations.getDeathBanConfiguration().getGroupBanTimeAttributeName();
+            if(groupBanTimeAttributeName != null) {
+                AugmentedHardcore.groupHandler = new LuckPermsGroupHandler(groupBanTimeAttributeName);
+            }
         }
 
         //register event listeners

--- a/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationDeathBan.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationDeathBan.java
@@ -29,8 +29,9 @@ public class ConfigurationDeathBan {
     private final String spectatorBanRespawnWorld;
     private final List<String> commandsOnDeathBan;
     private final List<String> disableBanInWorlds;
+    private final String groupBanTimeAttributeName;
 
-    public ConfigurationDeathBan(boolean useDeathBan, EnumMap<DamageCause, BanConfiguration> banTimes, BanList.Type banType, BanTimeType banTimeType, GrowthType banTimeByPlaytimeGrowthType, boolean selfHarmBan, boolean lightningOnDeathBan, String spectatorBanRespawnWorld, List<String> commandsOnDeathBan, List<String> disableBanInWorlds) {
+    public ConfigurationDeathBan(boolean useDeathBan, EnumMap<DamageCause, BanConfiguration> banTimes, BanList.Type banType, BanTimeType banTimeType, GrowthType banTimeByPlaytimeGrowthType, boolean selfHarmBan, boolean lightningOnDeathBan, String spectatorBanRespawnWorld, List<String> commandsOnDeathBan, List<String> disableBanInWorlds, String groupBanTimeAttributeName) {
         this.useDeathBan = useDeathBan;
         this.banTimes = banTimes;
         this.banType = banType;
@@ -41,6 +42,7 @@ public class ConfigurationDeathBan {
         this.spectatorBanRespawnWorld = spectatorBanRespawnWorld;
         this.commandsOnDeathBan = commandsOnDeathBan;
         this.disableBanInWorlds = disableBanInWorlds;
+        this.groupBanTimeAttributeName = groupBanTimeAttributeName;
     }
 
     public static ConfigurationDeathBan deserialize(ConfigurationSection section) {
@@ -57,6 +59,7 @@ public class ConfigurationDeathBan {
         String cSpectatorBanRespawnWorld = section.getString("SpectatorBanRespawnWorld", Bukkit.getWorlds().get(0).getName());
         List<String> cCommandsOnDeathBan = section.getStringList("CommandsOnDeathBan");
         List<String> cDisableBanInWorlds = section.getStringList("DisableBanInWorlds").stream().map(String::toLowerCase).toList();
+        String cGroupBanTimeAttributeName = section.getString("GroupBanTimeAttributeName", null);
 
         //loop over all damage causes
         ConfigurationSection banTimesConfigurations = section.getConfigurationSection("BanTimes");
@@ -83,7 +86,8 @@ public class ConfigurationDeathBan {
                 cLightningOnDeathBan,
                 cSpectatorBanRespawnWorld,
                 cCommandsOnDeathBan,
-                cDisableBanInWorlds
+                cDisableBanInWorlds,
+                cGroupBanTimeAttributeName
         );
     }
 
@@ -93,6 +97,10 @@ public class ConfigurationDeathBan {
 
     public List<String> getDisableBanInWorlds() {
         return disableBanInWorlds;
+    }
+
+    public String getGroupBanTimeAttributeName() {
+        return groupBanTimeAttributeName;
     }
 
     public BanList.Type getBanType() {

--- a/src/com/backtobedrock/augmentedhardcore/domain/enums/BanTimeType.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/enums/BanTimeType.java
@@ -2,7 +2,9 @@ package com.backtobedrock.augmentedhardcore.domain.enums;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.data.PlayerData;
+import com.backtobedrock.augmentedhardcore.groups.GroupHandler;
 import com.backtobedrock.augmentedhardcore.utilities.MessageUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.Statistic;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -10,6 +12,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.time.LocalDateTime;
 
 public enum BanTimeType {
+    GROUP,
     STATIC,
     BANCOUNT,
     PLAYTIME,
@@ -18,6 +21,19 @@ public enum BanTimeType {
     public int getBantime(Player player, PlayerData playerData, int max) {
         GrowthType growthType = JavaPlugin.getPlugin(AugmentedHardcore.class).getConfigurations().getDeathBanConfiguration().getBanTimeByPlaytimeGrowthType();
         switch (this) {
+            case GROUP:
+                try {
+                    GroupHandler groupHandler = AugmentedHardcore.getGroupHandler();
+                    String textValue = (String)groupHandler.getAttribute(player);
+                    if(!textValue.isEmpty()) {
+                        return Integer.parseInt(textValue);
+                    }
+                    Bukkit.getLogger().warning("No ban time value found in group attribute.");
+                } catch(Exception e) {
+                    Bukkit.getLogger().warning("Failed to determine ban time value based on group, configuration invalid: " + e);
+                    e.printStackTrace();
+                }
+                return 0;
             case STATIC:
                 return max;
             case BANCOUNT:

--- a/src/com/backtobedrock/augmentedhardcore/groups/DummyGroupHandler.java
+++ b/src/com/backtobedrock/augmentedhardcore/groups/DummyGroupHandler.java
@@ -1,0 +1,17 @@
+package com.backtobedrock.augmentedhardcore.groups;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Dummy group handler is used if LuckPerms is not
+ * available, to avoid hard class dependencies.
+ *
+ * @author Marcel Schoen
+ */
+public class DummyGroupHandler implements GroupHandler {
+
+    @Override
+    public Object getAttribute(Player player) {
+        return "";
+    }
+}

--- a/src/com/backtobedrock/augmentedhardcore/groups/GroupHandler.java
+++ b/src/com/backtobedrock/augmentedhardcore/groups/GroupHandler.java
@@ -1,0 +1,17 @@
+package com.backtobedrock.augmentedhardcore.groups;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Handles processing group attributes of a player.
+ *
+ * @author Marcel Schoen
+ */
+public interface GroupHandler {
+
+    /**
+     * @param player The player for which to look up the group attribute value.
+     * @return The attribute value (or null).
+     */
+    Object getAttribute(Player player);
+}

--- a/src/com/backtobedrock/augmentedhardcore/groups/LuckPermsGroupHandler.java
+++ b/src/com/backtobedrock/augmentedhardcore/groups/LuckPermsGroupHandler.java
@@ -1,0 +1,49 @@
+package com.backtobedrock.augmentedhardcore.groups;
+
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.model.group.Group;
+import net.luckperms.api.model.user.User;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+/**
+ * Reads the configured ban-time meta attribute from
+ * the player's LuckPerms group.
+ *
+ * @author Marcel Schoen
+ */
+public class LuckPermsGroupHandler implements GroupHandler {
+
+    private LuckPerms luckPerms = null;
+    private String attributeName = null;
+
+    /**
+     * @param attributeName The configured name of the LuckPerms group attribute.
+     */
+    public LuckPermsGroupHandler(String attributeName) {
+        RegisteredServiceProvider<LuckPerms> provider = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
+        if (provider != null) {
+            luckPerms = provider.getProvider();
+            this.attributeName = attributeName;
+        } else {
+            Bukkit.getLogger().warning("LuckPerms group handler not available!");
+        }
+    }
+
+    @Override
+    public Object getAttribute(Player player) {
+        if(luckPerms != null) {
+            User user = luckPerms.getPlayerAdapter(Player.class).getUser(player);
+            String groupName = user.getPrimaryGroup();
+            Group group = luckPerms.getGroupManager().getGroup(groupName);
+            if(group != null && luckPerms.getGroupManager().getGroup(groupName) != null) {
+                return luckPerms.getGroupManager().getGroup(groupName).getCachedData().getMetaData().getMetaValue(attributeName);
+            }
+        } else {
+            Bukkit.getLogger().warning("LuckPerms API not available, cannot resolve attribute '"
+                    + attributeName + "'!");
+        }
+        return "";
+    }
+}

--- a/src/com/backtobedrock/augmentedhardcore/groups/LuckPermsGroupHandler.java
+++ b/src/com/backtobedrock/augmentedhardcore/groups/LuckPermsGroupHandler.java
@@ -37,7 +37,8 @@ public class LuckPermsGroupHandler implements GroupHandler {
             User user = luckPerms.getPlayerAdapter(Player.class).getUser(player);
             String groupName = user.getPrimaryGroup();
             Group group = luckPerms.getGroupManager().getGroup(groupName);
-            if(group != null && luckPerms.getGroupManager().getGroup(groupName) != null) {
+            Bukkit.getLogger().info( "Group name: " + groupName + ", group: " + group.getName() + ", attribute name: " + attributeName);
+            if(group != null) {
                 return luckPerms.getGroupManager().getGroup(groupName).getCachedData().getMetaData().getMetaValue(attributeName);
             }
         } else {

--- a/src/resources/config.yml
+++ b/src/resources/config.yml
@@ -379,6 +379,10 @@ BanType: name
 
 #What ban time type should be used for calculating the bantime?
 #Static:             Above times will be used for bans.
+#Group:              The ban time will be the number of seconds defined in the metadata of the LuckPerms
+#                    group the player is member of. The metadata of the group must contain an attribute
+#                    that defines the bantime of the players in this group. See config setting 'GroupBanTimeAttributeName'
+#                    below to specify the name of the metadata attribute.
 #BanCount:           The amount of (times death banned * 35) will be used for determining the bantime.
 #                    Bantimes will increase the more death banned the player has been.
 #                    Above times will be used as maximum ban time.
@@ -390,6 +394,15 @@ BanType: name
 #                    Every death will reset the bantime back to 0, above times will be used as maximum ban time.
 # -> static/bancount/playtime/timesincelastdeath
 BanTimeType: static
+
+# IF "BanTimeType" is set to "group":
+# Name of LuckPerms group meta attribute containing the ban time in number of minutes.
+# Example LuckPerms group config lines:
+#
+# meta:
+#   - bantime:
+#       value: '960'
+GroupBanTimeAttributeName: bantime
 
 #At what rate should the ban time by playtime grow?
 #Linear:      a constant increase in bantime the more bancount/playtime/timesincelastdeath(P) you have (constant increase).


### PR DESCRIPTION
This feature allows to define ban times based on group membership, with the "LuckPerms" permission handling plugin. I am using this to implement rank-based ban times. Members of the default group (aka noobs) get banned only for 30 minutes; members of the "veteran" group get banned for 2 hours, members of the "elite" group for a full day. This allows me to balance out the advantages that come with the higher ranks with some harsher punishment.

The feature requires that the meta-data of the LuckPerms group contains an attribute with the ban time (number of seconds).